### PR TITLE
fix bug

### DIFF
--- a/example/ner/standard/run.py
+++ b/example/ner/standard/run.py
@@ -213,7 +213,7 @@ def main(cfg):
                 temp_1 = []
                 temp_2 = []
                 for j,m in enumerate(label):
-                    if j == 0:
+                    if m == 0 or logits[i][j] == 0:
                         continue
                     elif label_ids[i][j] == len(label_map):
                         y_true.append(temp_1)


### PR DESCRIPTION
跳过 label_ids 和 logits 中的 0 值。否则会报错 KeyError 0。
m 即 label_ids[i][j] ，而不是 j 。